### PR TITLE
refactored lifecycle to avoid multiple setStates

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -59,24 +59,19 @@ export default class VersionControl extends Component {
     }
 
     componentWillReceiveProps({debug, enabled, version}) {
+        const newState = {};
         if (debug !== this.props.debug) {
-            this.setState((state) => {
-                state.debug = debug;
-                return state;
-            })
+            newState.debug = debug;
         }
         if (enabled !== this.props.enabled) {
-            this.setState((state) => {
-                state.enabled = enabled;
-                return state;
-            })
+            newState.enabled = enabled;
         }
         if (version !== this.props.version) {
-            this.setState((state) => {
-                state.version = version;
-                return state;
-            })
+            newState.version = version;
         }
+        this.setState((state) => {
+            return {...state, ...newState};
+        });
     }
 
     componentWillUnmount() {


### PR DESCRIPTION
Small refactor in componentWillReceibeProps to avoid multiple setState calls. 

Small guide to run a PR locally before merge, in case you need it: https://help.github.com/en/articles/checking-out-pull-requests-locally